### PR TITLE
fix(lb): 최근 10초 롤링 평균으로 응답시간 계산 (Closes #1)

### DIFF
--- a/load-balancer/main.go
+++ b/load-balancer/main.go
@@ -16,11 +16,13 @@ import (
 
 // --- 통계 데이터 구조체 ---
 type StatsCollector struct {
-	mu                sync.RWMutex
-	requests          []time.Time // RPS 계산을 위해 요청 시간 기록
-	totalRequests     int64
-	successCount      int64
-	totalResponseTime time.Duration
+    mu                sync.RWMutex
+    requests          []time.Time // RPS 계산을 위해 요청 시간 기록
+    totalRequests     int64
+    successCount      int64
+    totalResponseTime time.Duration
+    // 최근 응답시간 샘플(롤링 평균 계산용)
+    responseSamples   []struct{ ts time.Time; dur time.Duration }
 }
 type requestMetrics map[string]interface{}
 
@@ -28,21 +30,35 @@ var stats = &StatsCollector{}
 
 // --- 통계 측정 미들웨어 ---
 func statsMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		startTime := time.Now()
-		resWrapper := &responseWriterInterceptor{ResponseWriter: w, statusCode: http.StatusOK}
-		next.ServeHTTP(resWrapper, r)
-		duration := time.Since(startTime)
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        startTime := time.Now()
+        resWrapper := &responseWriterInterceptor{ResponseWriter: w, statusCode: http.StatusOK}
+        next.ServeHTTP(resWrapper, r)
+        duration := time.Since(startTime)
 
-		stats.mu.Lock()
-		stats.totalRequests++
-		stats.requests = append(stats.requests, time.Now())
-		if resWrapper.statusCode >= 200 && resWrapper.statusCode < 400 {
-			stats.successCount++
-		}
-		stats.totalResponseTime += duration
-		stats.mu.Unlock()
-	})
+        stats.mu.Lock()
+        stats.totalRequests++
+        stats.requests = append(stats.requests, time.Now())
+        if resWrapper.statusCode >= 200 && resWrapper.statusCode < 400 {
+            stats.successCount++
+        }
+        stats.totalResponseTime += duration
+        // 응답시간 샘플 추가 (메모리 누수를 방지하기 위해 오래된 샘플은 주기적으로 정리)
+        now := time.Now()
+        stats.responseSamples = append(stats.responseSamples, struct{ ts time.Time; dur time.Duration }{ts: now, dur: duration})
+        // 60초 이전 샘플은 과감히 제거 (롤링 윈도우는 10초지만 버퍼를 조금 더 유지)
+        cutoff := now.Add(-60 * time.Second)
+        if len(stats.responseSamples) > 0 {
+            var kept []struct{ ts time.Time; dur time.Duration }
+            for _, s := range stats.responseSamples {
+                if s.ts.After(cutoff) {
+                    kept = append(kept, s)
+                }
+            }
+            stats.responseSamples = kept
+        }
+        stats.mu.Unlock()
+    })
 }
 
 // ... responseWriterInterceptor, getEnv, newProxy는 이전과 동일 ...
@@ -104,39 +120,63 @@ func main() {
 	uiProxy := newProxy(dashboardUIURL)
 
 	// --- [핵심] /stats 핸들러 최종 수정 ---
-	mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
-		stats.mu.Lock()
-		// RPS 계산: 최근 10초간의 요청 수를 10으로 나눔
-		now := time.Now()
-		tenSecondsAgo := now.Add(-10 * time.Second)
-		var recentRequests int
-		var newRequests []time.Time
-		for _, t := range stats.requests {
-			if t.After(tenSecondsAgo) {
-				recentRequests++
-				newRequests = append(newRequests, t)
-			}
-		}
-		stats.requests = newRequests // 오래된 요청 기록은 삭제
-		rps := float64(recentRequests) / 10.0
+    mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
+        stats.mu.Lock()
+        // RPS 계산: 최근 10초간의 요청 수를 10으로 나눔
+        now := time.Now()
+        tenSecondsAgo := now.Add(-10 * time.Second)
+        var recentRequests int
+        var newRequests []time.Time
+        for _, t := range stats.requests {
+            if t.After(tenSecondsAgo) {
+                recentRequests++
+                newRequests = append(newRequests, t)
+            }
+        }
+        stats.requests = newRequests // 오래된 요청 기록은 삭제
+        rps := float64(recentRequests) / 10.0
 
-		// 나머지 통계 계산
-		var avgResponseTimeMs float64
-		if stats.totalRequests > 0 {
-			avgResponseTimeMs = float64(stats.totalResponseTime.Milliseconds()) / float64(stats.totalRequests)
-		}
-		var successRate float64
-		if stats.totalRequests > 0 {
-			successRate = (float64(stats.successCount) / float64(stats.totalRequests)) * 100
-		}
+        // 평균 응답시간 계산
+        // 1) 롤링 평균(최근 10초)
+        var rollingDurSum time.Duration
+        var rollingCount int64
+        var keptSamples []struct{ ts time.Time; dur time.Duration }
+        for _, s := range stats.responseSamples {
+            if s.ts.After(tenSecondsAgo) {
+                rollingDurSum += s.dur
+                rollingCount++
+                keptSamples = append(keptSamples, s)
+            }
+        }
+        // 샘플 슬라이스에서 오래된 항목 제거
+        stats.responseSamples = keptSamples
 
-		combinedStats := requestMetrics{
-			"load-balancer": requestMetrics{
-				"total_requests": stats.totalRequests, "success_rate": successRate,
-				"avg_response_time_ms": avgResponseTimeMs, "requests_per_second": rps, "status": "healthy",
-			},
-		}
-		stats.mu.Unlock()
+        var avgResponseTimeMs float64 // 롤링 평균(ms)
+        if rollingCount > 0 {
+            avgResponseTimeMs = float64(rollingDurSum.Milliseconds()) / float64(rollingCount)
+        }
+
+        // 2) 레퍼런스용: 전체(lifetime) 평균(ms)
+        var lifetimeAvgMs float64
+        if stats.totalRequests > 0 {
+            lifetimeAvgMs = float64(stats.totalResponseTime.Milliseconds()) / float64(stats.totalRequests)
+        }
+        var successRate float64
+        if stats.totalRequests > 0 {
+            successRate = (float64(stats.successCount) / float64(stats.totalRequests)) * 100
+        }
+
+        combinedStats := requestMetrics{
+            "load-balancer": requestMetrics{
+                "total_requests": stats.totalRequests, "success_rate": successRate,
+                // 대시보드는 avg_response_time_ms를 사용하므로 롤링 평균을 기본으로 제공합니다.
+                "avg_response_time_ms": avgResponseTimeMs,
+                // 참고용으로 lifetime 평균도 제공합니다.
+                "avg_response_time_ms_lifetime": lifetimeAvgMs,
+                "requests_per_second": rps, "status": "healthy",
+            },
+        }
+        stats.mu.Unlock()
 
 		// --- [수정] 모든 서비스의 통계를 가져오도록 확장 ---
 		var wg sync.WaitGroup


### PR DESCRIPTION
## 변경 요약
- 로드밸런서의 평균 응답시간을 전체(lifetime) 평균 대신 최근 10초 롤링 평균으로 계산해 대시보드에 반영. 참고용으로 기존 lifetime 평균도 별도 필드로 노출

## 배경/이슈
- 응답 시간이 1.333으로 고정되어 최신 트래픽을 반영하지 않는 문제 해결. Closes #1

## 주요 변경
- statsMiddleware: 응답시간 샘플을 시간과 함께 저장, 60초 이전 샘플 정리
- /stats: 최근 10초 샘플 기반 롤링 평균 계산 → avg_response_time_ms로 제공
- lifetime 평균은 avg_response_time_ms_lifetime로 별도 제공
- 영향 범위: 대시보드 “응답 시간 추이”가 트래픽 변화에 민감하게 반응

## 테스트 방법
```
curl -s http://localhost:7100/stats | jq '."load-balancer" | {avg_response_time_ms, avg_response_time_ms_lifetime, requests_per_second}'
```
대시보드(http://localhost:7100/) 응답시간 차트가 트래픽 변화에 따라 변하는지 확인

## 결과
- 스크린샷
<img width="719" height="426" alt="스크린샷 2025-09-03 오후 1 12 36" src="https://github.com/user-attachments/assets/d1e28d4e-fb21-4b1d-ab67-0014ced7a269" />

- 실행 결과
```
curl -s http://localhost:7100/stats | jq '."load-balancer" | {avg_response_time_ms, requests_per_second}'
{
  "avg_response_time_ms": 0.667687595712098,
  "requests_per_second": 65.3
```

## 체크리스트
- [x] 이동 평균(ms)이 부하 변화에 따라 갱신됨 
- [x] lifetime 평균 필드가 존재하고 값이 논리적임
- [x] /와 /api/posts 라우트 모두에서 total_requests가 반영됨

## 변경 파일
load-balancer/main.go